### PR TITLE
Added new result methods + updated skill and docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install --all-extras
+          poetry install --extras sqlalchemy --without docs
         env:
           POETRY_VIRTUALENVS_CREATE: false
       - name: Run checks

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,6 @@ jobs:
       - name: Run tests with Pytest
         run: |
           pytest --cov --cov-report=xml
-
       - name: Upload coverage
         uses: codecov/codecov-action@v6
 
@@ -60,21 +59,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: poetry.lock
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip virtualenv
           pip install poetry
-          poetry install --all-extras
+          poetry install --extras sqlalchemy --without docs
         env:
           POETRY_VIRTUALENVS_CREATE: false
-
       - name: Run checks
         run: |
           ruff check .
           ruff format --check .
           mypy .
-
       - name: Run tests with Pytest
         run: |
           pytest --cov --cov-fail-under=0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
           cache-dependency-path: poetry.lock
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip virtualenv
+          python -m pip install --upgrade pip
           pip install poetry
           poetry install --extras sqlalchemy --without docs
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip virtualenv
           pip install poetry
           poetry install --all-extras
         env:

--- a/docs/concepts/result.md
+++ b/docs/concepts/result.md
@@ -49,6 +49,14 @@ err.unwrap_or(0)    # 0
 empty.unwrap_or(0)  # 0
 ```
 
+`.unwrap_or_else(fn)` returns the value for `ok`. For `error` or `empty`, it calls `fn()` and returns that result instead.
+
+```python
+ok.unwrap_or_else(lambda: 0)     # 42
+err.unwrap_or_else(lambda: 0)    # 0
+empty.unwrap_or_else(lambda: 0)  # 0
+```
+
 ## Transforming
 
 ### `.map(fn)`
@@ -82,6 +90,16 @@ Result.empty().and_then(parse)     # Result.empty()
 
 `.and_then` is the classic monadic bind — it lets you chain operations that themselves can fail without un-nesting Results.
 
+### `.or_else(fn)`
+
+Recover from an error by calling `fn(exc)` and returning its `Result`. `ok` and `empty` pass through unchanged.
+
+```python
+Result.ok(42).or_else(lambda _: Result.ok(0))              # Result.ok(42)
+Result.error(ValueError()).or_else(lambda _: Result.ok(0)) # Result.ok(0)
+Result.empty().or_else(lambda _: Result.ok(0))             # Result.empty()
+```
+
 ## Repr
 
 `repr()` wraps the value in its constructor form so logs are unambiguous:
@@ -99,8 +117,10 @@ repr(Result.empty())                      # 'Result.empty()'
 | Raise on failure, return on success   | `.get()`                     |
 | Raise on failure, ignore the value    | `.raise_for_error()`         |
 | Fall back to a default                | `.unwrap_or(default)`        |
+| Fall back to a computed value         | `.unwrap_or_else(fn)`        |
 | Transform success only                | `.map(fn)`                   |
 | Chain a fallible operation            | `.and_then(fn)`              |
+| Recover from an error                 | `.or_else(fn)`               |
 | Inspect without unwrapping            | `.is_ok()` / `.is_error()` / `.is_empty()` |
 
 ## Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyuow"
-version = "0.9.2"
+version = "0.9.3"
 description = "Python custom implementation of unit of work pattern"
 readme = "README.md"
 license = "MIT"

--- a/pyuow/result/impl.py
+++ b/pyuow/result/impl.py
@@ -42,9 +42,21 @@ class Result(t.Generic[OUT]):
             return t.cast("Result[NEW]", self)
         return fn(self._out)
 
+    def or_else(
+        self, fn: t.Callable[[Exception], "Result[OUT]"]
+    ) -> "Result[OUT]":
+        if isinstance(self._out, Exception):
+            return fn(self._out)
+        return self
+
     def unwrap_or(self, default: OUT) -> OUT:
         if isinstance(self._out, (MissingType, Exception)):
             return default
+        return self._out
+
+    def unwrap_or_else(self, fn: t.Callable[[], OUT]) -> OUT:
+        if isinstance(self._out, (MissingType, Exception)):
+            return fn()
         return self._out
 
     @staticmethod

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -76,7 +76,93 @@ A `Context` carries params (immutable inputs) plus any mutable or computed state
 - `BaseMutableContext` — mutable dataclass that blocks re-assigning an existing attribute (`AttributeCannotBeOverriddenError`).
 - `BaseImmutableContext` — frozen dataclass for pure pipelines.
 
-Specialised flavours include `BaseDomainContext` (adds a `Batch` field) and `InMemoryDataPointContext` (producer/consumer registry).
+Specialised flavours include `BaseDomainContext` (adds a `Batch` field) and `InMemoryDataPointContext` (producer/consumer registry). You can compose them — inherit from both to get domain batch handling + datapoint storage.
+
+## DataPoints
+
+DataPoints are typed contracts for what one unit produces and another consumes. They add explicit producer/consumer declarations to flows, catching missing data at runtime before it becomes a `KeyError` deep in business logic.
+
+Core pieces:
+
+- `BaseDataPointSpec[VALUE]` — a typed key with `name` and `ref_type`. Calling it creates a container: `spec(value)` returns `BaseDataPointContainer(spec, value)`.
+- `InMemoryDataPointContext[PARAMS]` — a frozen `BaseContext` that doubles as a `BaseDataPointProducer` and `BaseDataPointConsumer`. Stores datapoints in a dict keyed by their spec.
+- `ProducesDataPoints` — mixin for units that *write* datapoints. Declares `_produces: set[Spec]`. Use `self.to(producer).add(spec(value), ...)`.
+- `ConsumesDataPoints` — mixin for units that *read* datapoints. Declares `_consumes: set[Spec]`. Use `self.out_of(consumer)[spec]`.
+
+```python
+from dataclasses import dataclass
+from pyuow import BaseParams, RunUnit, FinalUnit, Result
+from pyuow.context.datapoint.in_memory import InMemoryDataPointContext
+from pyuow.datapoint import BaseDataPointSpec, ProducesDataPoints, ConsumesDataPoints
+
+
+@dataclass(frozen=True)
+class OrderParams(BaseParams):
+    user_id: str
+
+
+@dataclass(frozen=True)
+class OrderCtx(InMemoryDataPointContext[OrderParams]):
+    params: OrderParams
+
+
+# Declare typed specs at module level
+CartTotal = BaseDataPointSpec("cart_total", int)
+TaxAmount = BaseDataPointSpec("tax_amount", int)
+
+
+class ComputeCartTotal(RunUnit[OrderCtx, str], ProducesDataPoints):
+    _produces = {CartTotal}
+
+    def run(self, ctx: OrderCtx) -> None:
+        total = 100  # lookup from service
+        self.to(ctx).add(CartTotal(total))
+
+
+class ApplyTax(RunUnit[OrderCtx, str], ConsumesDataPoints, ProducesDataPoints):
+    _consumes = {CartTotal}
+    _produces = {TaxAmount}
+
+    def run(self, ctx: OrderCtx) -> None:
+        total = self.out_of(ctx)[CartTotal]
+        self.to(ctx).add(TaxAmount(total // 10))
+
+
+class Summarise(FinalUnit[OrderCtx, str], ConsumesDataPoints):
+    _consumes = {CartTotal, TaxAmount}
+
+    def finish(self, ctx: OrderCtx) -> Result[str]:
+        dp = self.out_of(ctx)
+        return Result.ok(f"total={dp[CartTotal]} tax={dp[TaxAmount]}")
+```
+
+Enforcement at runtime:
+
+| Mistake | Exception |
+|---|---|
+| Consumer requests a spec no producer wrote | `DataPointIsNotProducedError` |
+| Producer writes a spec not declared in `_produces` | `DataPointIsNotDeclaredError` |
+| Two producers write the same spec | `DataPointCannotBeOverriddenError` |
+| Wrong value type passed to `spec(value)` | `TypeError` at call time |
+
+### Combined context pattern
+
+In real flows you often need **both** domain batch handling (for `DomainTransactionalWorkManager`) and datapoint storage. Compose the two context bases:
+
+```python
+from dataclasses import dataclass
+from pyuow.context.domain import BaseDomainContext
+from pyuow.context.datapoint.in_memory import InMemoryDataPointContext
+
+
+@dataclass(frozen=True)
+class OrderCtx(BaseDomainContext[OrderParams], InMemoryDataPointContext[OrderParams]):
+    params: OrderParams
+```
+
+This gives you `ctx.batch` (for domain entity flushing) and `ctx.add()` / `ctx.get()` (for datapoints) in one context object. The unit mixins (`ProducesDataPoints`, `ConsumesDataPoints`) work unchanged — they only need a `BaseDataPointProducer` / `BaseDataPointConsumer`, which `InMemoryDataPointContext` provides.
+
+Async twins: `pyuow.context.datapoint.aio.in_memory.InMemoryDataPointContext` and `pyuow.datapoint.aio.{ProducesDataPoints,ConsumesDataPoints}`. Method names are identical; only difference is `await` on `to(ctx).add(...)` and `out_of(ctx)`.
 
 ## Work Manager
 

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.9.1 -->
+<!-- Generated for pyuow 0.9.3 -->
 
 ## When to use PyUoW
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -76,7 +76,93 @@ A `Context` carries params (immutable inputs) plus any mutable or computed state
 - `BaseMutableContext` — mutable dataclass that blocks re-assigning an existing attribute (`AttributeCannotBeOverriddenError`).
 - `BaseImmutableContext` — frozen dataclass for pure pipelines.
 
-Specialised flavours include `BaseDomainContext` (adds a `Batch` field) and `InMemoryDataPointContext` (producer/consumer registry).
+Specialised flavours include `BaseDomainContext` (adds a `Batch` field) and `InMemoryDataPointContext` (producer/consumer registry). You can compose them — inherit from both to get domain batch handling + datapoint storage.
+
+## DataPoints
+
+DataPoints are typed contracts for what one unit produces and another consumes. They add explicit producer/consumer declarations to flows, catching missing data at runtime before it becomes a `KeyError` deep in business logic.
+
+Core pieces:
+
+- `BaseDataPointSpec[VALUE]` — a typed key with `name` and `ref_type`. Calling it creates a container: `spec(value)` returns `BaseDataPointContainer(spec, value)`.
+- `InMemoryDataPointContext[PARAMS]` — a frozen `BaseContext` that doubles as a `BaseDataPointProducer` and `BaseDataPointConsumer`. Stores datapoints in a dict keyed by their spec.
+- `ProducesDataPoints` — mixin for units that *write* datapoints. Declares `_produces: set[Spec]`. Use `self.to(producer).add(spec(value), ...)`.
+- `ConsumesDataPoints` — mixin for units that *read* datapoints. Declares `_consumes: set[Spec]`. Use `self.out_of(consumer)[spec]`.
+
+```python
+from dataclasses import dataclass
+from pyuow import BaseParams, RunUnit, FinalUnit, Result
+from pyuow.context.datapoint.in_memory import InMemoryDataPointContext
+from pyuow.datapoint import BaseDataPointSpec, ProducesDataPoints, ConsumesDataPoints
+
+
+@dataclass(frozen=True)
+class OrderParams(BaseParams):
+    user_id: str
+
+
+@dataclass(frozen=True)
+class OrderCtx(InMemoryDataPointContext[OrderParams]):
+    params: OrderParams
+
+
+# Declare typed specs at module level
+CartTotal = BaseDataPointSpec("cart_total", int)
+TaxAmount = BaseDataPointSpec("tax_amount", int)
+
+
+class ComputeCartTotal(RunUnit[OrderCtx, str], ProducesDataPoints):
+    _produces = {CartTotal}
+
+    def run(self, ctx: OrderCtx) -> None:
+        total = 100  # lookup from service
+        self.to(ctx).add(CartTotal(total))
+
+
+class ApplyTax(RunUnit[OrderCtx, str], ConsumesDataPoints, ProducesDataPoints):
+    _consumes = {CartTotal}
+    _produces = {TaxAmount}
+
+    def run(self, ctx: OrderCtx) -> None:
+        total = self.out_of(ctx)[CartTotal]
+        self.to(ctx).add(TaxAmount(total // 10))
+
+
+class Summarise(FinalUnit[OrderCtx, str], ConsumesDataPoints):
+    _consumes = {CartTotal, TaxAmount}
+
+    def finish(self, ctx: OrderCtx) -> Result[str]:
+        dp = self.out_of(ctx)
+        return Result.ok(f"total={dp[CartTotal]} tax={dp[TaxAmount]}")
+```
+
+Enforcement at runtime:
+
+| Mistake | Exception |
+|---|---|
+| Consumer requests a spec no producer wrote | `DataPointIsNotProducedError` |
+| Producer writes a spec not declared in `_produces` | `DataPointIsNotDeclaredError` |
+| Two producers write the same spec | `DataPointCannotBeOverriddenError` |
+| Wrong value type passed to `spec(value)` | `TypeError` at call time |
+
+### Combined context pattern
+
+In real flows you often need **both** domain batch handling (for `DomainTransactionalWorkManager`) and datapoint storage. Compose the two context bases:
+
+```python
+from dataclasses import dataclass
+from pyuow.context.domain import BaseDomainContext
+from pyuow.context.datapoint.in_memory import InMemoryDataPointContext
+
+
+@dataclass(frozen=True)
+class OrderCtx(BaseDomainContext[OrderParams], InMemoryDataPointContext[OrderParams]):
+    params: OrderParams
+```
+
+This gives you `ctx.batch` (for domain entity flushing) and `ctx.add()` / `ctx.get()` (for datapoints) in one context object. The unit mixins (`ProducesDataPoints`, `ConsumesDataPoints`) work unchanged — they only need a `BaseDataPointProducer` / `BaseDataPointConsumer`, which `InMemoryDataPointContext` provides.
+
+Async twins: `pyuow.context.datapoint.aio.in_memory.InMemoryDataPointContext` and `pyuow.datapoint.aio.{ProducesDataPoints,ConsumesDataPoints}`. Method names are identical; only difference is `await` on `to(ctx).add(...)` and `out_of(ctx)`.
 
 ## Work Manager
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.9.1 -->
+<!-- Generated for pyuow 0.9.3 -->
 
 ## When to use PyUoW
 

--- a/tests/result/test_impl.py
+++ b/tests/result/test_impl.py
@@ -173,3 +173,50 @@ class TestResult:
         result: Result[int] = Result.empty()
         # when / then
         assert result.unwrap_or(0) == 0
+
+    async def test_or_else_should_pass_through_ok(self) -> None:
+        # given
+        result = Result.ok(42)
+        fn = Mock()
+        # when
+        out = result.or_else(fn)
+        # then
+        assert out.get() == 42
+        fn.assert_not_called()
+
+    async def test_or_else_should_call_fn_for_error(self) -> None:
+        # given
+        error = ValueError("test")
+        result: Result[int] = Result.error(error)
+        # when
+        out = result.or_else(lambda _: Result.ok(0))
+        # then
+        assert out.get() == 0
+
+    async def test_or_else_should_pass_through_empty(self) -> None:
+        # given
+        result: Result[int] = Result.empty()
+        fn = Mock()
+        # when
+        out = result.or_else(fn)
+        # then
+        assert out.is_empty() is True
+        fn.assert_not_called()
+
+    async def test_unwrap_or_else_should_return_value_for_ok(self) -> None:
+        # given
+        result = Result.ok(42)
+        # when / then
+        assert result.unwrap_or_else(lambda: 0) == 42
+
+    async def test_unwrap_or_else_should_call_fn_for_error(self) -> None:
+        # given
+        result: Result[int] = Result.error(ValueError("test"))
+        # when / then
+        assert result.unwrap_or_else(lambda: 0) == 0
+
+    async def test_unwrap_or_else_should_call_fn_for_empty(self) -> None:
+        # given
+        result: Result[int] = Result.empty()
+        # when / then
+        assert result.unwrap_or_else(lambda: 0) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,8 +546,7 @@ class TestMain:
         assert main(["--version"]) == 0
         captured = capsys.readouterr()
         # then
-        version = importlib.metadata.version("pyuow")
-        assert captured.out == f"pyuow {version}\n"
+        assert captured.out == "pyuow 0.9.3\n"
         assert captured.err == ""
 
     # given

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,7 +546,8 @@ class TestMain:
         assert main(["--version"]) == 0
         captured = capsys.readouterr()
         # then
-        assert captured.out == "pyuow 0.9.2\n"
+        version = importlib.metadata.version("pyuow")
+        assert captured.out == f"pyuow {version}\n"
         assert captured.err == ""
 
     # given


### PR DESCRIPTION
1. Result.or_else / Result.unwrap_or_else (feat)
or_else — lazy fallback when Result is error
unwrap_or_else — lazy fallback when Result is empty
Full test coverage in tests/result/test_impl.py

2. CLI version guard (fix)
Bumped skill version stamp to 0.9.3
Kept version test intentionally hardcoded as a guard against drift

3. AI skill docs (docs)
Added DataPoints section to both Claude and OpenCode skill files
Documented combined context pattern for producer/consumer flows