### PR TITLE
ci: upgrade setuptools before pip-audit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,9 @@ jobs:
           cache-dependency-path: poetry.lock
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          # setuptools ships with the runner image, not with poetry.lock; keep it
+          # current so the audit below is not tripped by toolchain-only CVEs
+          python -m pip install --upgrade pip setuptools
           pip install poetry
           poetry install --extras sqlalchemy --without docs
         env:


### PR DESCRIPTION
## Problem

`PyUoW-build` is red on `main` at the **Audit dependencies** step:

```
Found 2 known vulnerabilities in 1 package
Name       Version ID              Fix Versions
---------- ------- --------------- ------------
setuptools 79.0.1  PYSEC-2026-3447 83.0.0
```

`pip-audit` is invoked bare, so it audits the **entire runner environment** rather than PyUoW's dependency graph. `setuptools` is not a PyUoW dependency — it appears in neither `pyproject.toml` nor `poetry.lock`. The 79.0.1 being flagged is what `actions/setup-python` preinstalls in the hosted toolcache.

So the build fails on a CVE in the runner's build toolchain (PYSEC-2026-3447 / CVE-2026-59890 — a `MANIFEST.in` exclusion bypass via Unicode normalization on APFS/HFS+) that has nothing to do with this project.

## Fix

Upgrade `setuptools` alongside `pip` in the `ubuntu-checks` install step, so the audit sees the fixed 83.0.0+ line.

- Remediates rather than suppresses — no `--ignore-vuln`.
- `setuptools` 83+ requires Python `>=3.10`; the matrix floor is already 3.10, so every job can take the upgrade.
- Only `ubuntu-checks` is touched — it is the only job that runs `pip-audit`.

## Worth knowing

This keeps the audit's scope unchanged, which means the same class of failure can recur whenever the runner image ships a `pip`/`setuptools` with a fresh CVE. The durable alternative is to point `pip-audit` at the project's locked dependencies instead of the ambient environment (`poetry export` + `pip-audit -r`), which is a bigger change than a build fix and is left as a follow-up call.
