### PR TITLE
feat(repository): view repositories for read models

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ assert result.get() == "greeted"
 | [Work Manager](https://s-m-a-d.github.io/PyUoW/concepts/work/)                | NoOp, transactional, and domain-transactional managers                       |
 | [Domain Model](https://s-m-a-d.github.io/PyUoW/concepts/domain/)              | `Entity`, `AuditedEntity`, `Model`, `Batch`, events, typed exceptions        |
 | [DataPoints](https://s-m-a-d.github.io/PyUoW/concepts/datapoints/)            | Typed producer / consumer contracts between units                            |
-| [SQLAlchemy](https://s-m-a-d.github.io/PyUoW/integrations/sqlalchemy/)        | Ready-made repositories, table mixins, and transaction manager               |
+| [SQLAlchemy](https://s-m-a-d.github.io/PyUoW/integrations/sqlalchemy/)        | Ready-made entity and view repositories, table mixins, transaction manager   |
 | [Async](https://s-m-a-d.github.io/PyUoW/async/)                               | A sync and an `aio/` twin for every primitive                                |
 
 ## Contributing

--- a/docs/api/contrib-sqlalchemy.md
+++ b/docs/api/contrib-sqlalchemy.md
@@ -16,6 +16,7 @@ pip install "pyuow[sqlalchemy]"
         - AuditedEntityTable
         - SoftDeletableEntityTable
         - VersionedEntityTable
+        - ViewTable
 
 ## Sync work
 
@@ -33,6 +34,8 @@ pip install "pyuow[sqlalchemy]"
       members:
         - BaseSqlAlchemyEntityRepository
         - BaseSqlAlchemyRepositoryFactory
+        - BaseSqlAlchemyViewRepository
+        - BaseSqlAlchemyViewRepositoryFactory
 
 ## Async work
 
@@ -50,3 +53,5 @@ pip install "pyuow[sqlalchemy]"
       members:
         - BaseSqlAlchemyEntityRepository
         - BaseSqlAlchemyRepositoryFactory
+        - BaseSqlAlchemyViewRepository
+        - BaseSqlAlchemyViewRepositoryFactory

--- a/docs/api/repository.md
+++ b/docs/api/repository.md
@@ -9,6 +9,8 @@ Repository ABCs and the domain batch processor.
         - BaseWriteOnlyEntityRepository
         - BaseEntityRepository
         - BaseRepositoryFactory
+        - BaseViewRepository
+        - BaseViewRepositoryFactory
 
 ## `pyuow.repository.domain`
 
@@ -23,6 +25,8 @@ Repository ABCs and the domain batch processor.
         - BaseWriteOnlyEntityRepository
         - BaseEntityRepository
         - BaseRepositoryFactory
+        - BaseViewRepository
+        - BaseViewRepositoryFactory
 
 ## `pyuow.repository.aio.domain`
 

--- a/docs/integrations/sqlalchemy.md
+++ b/docs/integrations/sqlalchemy.md
@@ -311,19 +311,29 @@ class UserStatsViewRepository(
         )
 
     def for_user(self, user_id: UserId) -> t.Optional[UserStats]:
-        return self.find_by(
-            self.select().where(self._table.user_id == user_id)
-        )
+        return self.find_by(self._table.user_id == user_id)
 
+    def big_spenders(self, threshold: int) -> t.Iterable[UserStats]:
+        return self.find_all_by(self._table.total_spent >= threshold)
+```
+
+`to_view` is the only abstract member. The four read methods take a **whereclause**, not a whole statement — the base wraps it as `SELECT ... FROM <view> WHERE <criteria>` for you. Combine several conditions with `and_()` / `or_()`. `find_*` return `None` or an empty sequence when nothing matches, `get_by` raises, `exists_by` returns a bool. Your own finders name the access paths that make sense for the view, and callers never build SQL.
+
+For anything a whereclause cannot express — ordering, limits, joins, aggregates — `select()` gives you the base `Select` over the view table and you run it yourself:
+
+```python
     def top_spenders(self, limit: int = 10) -> t.Iterable[UserStats]:
-        return self.find_all_by(
+        statement = (
             self.select()
             .order_by(self._table.total_spent.desc())
             .limit(limit)
         )
-```
 
-`to_view` is the only abstract member. The base gives you `select()` to start a statement plus `find_by` / `find_all_by` / `get_by` / `exists_by` to run one — `find_*` return `None` or an empty sequence when nothing matches, `get_by` raises. Your own finders name the access paths that make sense for the view, and callers never build SQL.
+        with self._readonly_transaction_manager.transaction() as trx:
+            records = (trx.it().execute(statement)).scalars().all()
+
+        return [self.to_view(record) for record in records]
+```
 
 ### Wire up the factory
 

--- a/docs/integrations/sqlalchemy.md
+++ b/docs/integrations/sqlalchemy.md
@@ -5,7 +5,9 @@ PyUoW ships a SQLAlchemy 2.x integration under `pyuow.contrib.sqlalchemy` (sync)
 - `SqlAlchemyTransactionManager` / `SqlAlchemyReadOnlyTransactionManager` — concrete transaction managers compatible with `TransactionalWorkManager`.
 - `BaseSqlAlchemyEntityRepository` — implements `BaseEntityRepository` against any `EntityTable`.
 - `BaseSqlAlchemyRepositoryFactory` — wires repositories together for use with `DomainTransactionalWorkManager`.
+- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views, and their factory.
 - `EntityTable` / `AuditedEntityTable` / `SoftDeletableEntityTable` / `VersionedEntityTable` — `DeclarativeBase` mixins that mirror the entity hierarchy.
+- `ViewTable` — `DeclarativeBase` mixin for mapping a database view.
 
 Install the extra:
 
@@ -256,6 +258,128 @@ The manager:
 
 ---
 
+## Read-only views
+
+A database view is a read model, not an entity: there is nothing to `add`, `update` or `delete`, and the access path is normally a predicate rather than an id. PyUoW models views with a parallel hierarchy — `View`, `BaseViewRepository`, `BaseViewRepositoryFactory` — so a view can never end up in a `Batch` or in the entity `repositories` mapping by accident.
+
+### Map the view
+
+```python
+from uuid import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from pyuow.contrib.sqlalchemy.tables import ViewTable
+
+
+class UserStatsViewTable(ViewTable):
+    __tablename__ = "user_stats"
+
+    user_id: Mapped[UUID] = mapped_column(primary_key=True)
+    orders_count: Mapped[int]
+    total_spent: Mapped[int]
+```
+
+SQLAlchemy needs a primary key to identity-map rows. A view has none, so mark the column (or columns) that are unique in practice — it is a mapping-level declaration and the database is not asked to enforce it.
+
+### Define the read model
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UserStats:
+    user_id: UserId
+    orders_count: int
+    total_spent: int
+```
+
+### Write the repository
+
+```python
+from pyuow.contrib.sqlalchemy.repository import BaseSqlAlchemyViewRepository
+
+
+class UserStatsViewRepository(
+    BaseSqlAlchemyViewRepository[UserStats, UserStatsViewTable]
+):
+    @staticmethod
+    def to_view(record: UserStatsViewTable) -> UserStats:
+        return UserStats(
+            user_id=UserId(record.user_id),
+            orders_count=record.orders_count,
+            total_spent=record.total_spent,
+        )
+
+    def for_user(self, user_id: UserId) -> t.Optional[UserStats]:
+        return self.find_by(
+            self.select().where(self._table.user_id == user_id)
+        )
+
+    def top_spenders(self, limit: int = 10) -> t.Iterable[UserStats]:
+        return self.find_all_by(
+            self.select()
+            .order_by(self._table.total_spent.desc())
+            .limit(limit)
+        )
+```
+
+`to_view` is the only abstract member. The base gives you `select()` to start a statement plus `find_by` / `find_all_by` / `get_by` / `exists_by` to run one — `find_*` return `None` or an empty sequence when nothing matches, `get_by` raises. Your own finders name the access paths that make sense for the view, and callers never build SQL.
+
+### Wire up the factory
+
+`BaseSqlAlchemyViewRepositoryFactory` mirrors `BaseSqlAlchemyRepositoryFactory` but only needs the read-only transaction manager. One class can serve both sides:
+
+```python
+from pyuow.contrib.sqlalchemy.repository import (
+    BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepositoryFactory,
+)
+from pyuow.repository import BaseEntityRepository, BaseViewRepository
+
+
+class Repositories(
+    BaseSqlAlchemyRepositoryFactory, BaseSqlAlchemyViewRepositoryFactory
+):
+    @property
+    def repositories(self) -> t.Mapping[
+        t.Type[Entity[t.Any]],
+        BaseEntityRepository[t.Any, t.Any],
+    ]:
+        return {
+            User: UserRepository(
+                UserTable,
+                self._transaction_manager,
+                self._readonly_transaction_manager,
+            ),
+        }
+
+    @property
+    def views(self) -> t.Mapping[
+        t.Type[t.Any],
+        BaseViewRepository[t.Any, t.Any],
+    ]:
+        return {
+            UserStats: UserStatsViewRepository(
+                UserStatsViewTable,
+                self._readonly_transaction_manager,
+            ),
+        }
+
+    def users(self) -> UserRepository:
+        return t.cast(UserRepository, self.repo_for(User))
+
+    def user_stats(self) -> UserStatsViewRepository:
+        return t.cast(UserStatsViewRepository, self.view_for(UserStats))
+```
+
+`view_for(UserStats)` returns the registered repository as a `BaseViewRepository[UserStats, ...]`, so — exactly as with `repo_for` — the explicit accessor is what exposes the view's own finders.
+
+### Materialized views
+
+A materialized view maps the same way. `REFRESH MATERIALIZED VIEW` is a write and is deliberately outside the read-only repository: refresh it from a scheduler, a migration, or a dedicated unit that owns a write transaction.
+
+---
+
 ## Async
 
 The async surface mirrors the sync one. Imports change to `.aio`:
@@ -270,6 +394,8 @@ from pyuow.contrib.sqlalchemy.aio.work import (
 from pyuow.contrib.sqlalchemy.aio.repository import (
     BaseSqlAlchemyEntityRepository,
     BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepository,
+    BaseSqlAlchemyViewRepositoryFactory,
 )
 from pyuow.work.aio.transactional import TransactionalWorkManager
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyuow"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python custom implementation of unit of work pattern"
 readme = "README.md"
 license = "MIT"

--- a/pyuow/contrib/sqlalchemy/aio/repository/__init__.py
+++ b/pyuow/contrib/sqlalchemy/aio/repository/__init__.py
@@ -1,9 +1,13 @@
 from .base import (
     BaseSqlAlchemyEntityRepository,
     BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepository,
+    BaseSqlAlchemyViewRepositoryFactory,
 )
 
 __all__ = (
     "BaseSqlAlchemyEntityRepository",
     "BaseSqlAlchemyRepositoryFactory",
+    "BaseSqlAlchemyViewRepository",
+    "BaseSqlAlchemyViewRepositoryFactory",
 )

--- a/pyuow/contrib/sqlalchemy/aio/repository/base.py
+++ b/pyuow/contrib/sqlalchemy/aio/repository/base.py
@@ -29,6 +29,7 @@ from .....contrib.sqlalchemy.tables import (
     AuditedEntityTable,
     EntityTable,
     VersionedEntityTable,
+    ViewTable,
 )
 from .....entity import (
     AuditedEntity,
@@ -36,11 +37,18 @@ from .....entity import (
     SoftDeletableEntity,
     VersionedEntity,
 )
-from .....repository.aio import BaseEntityRepository, BaseRepositoryFactory
+from .....repository.aio import (
+    BaseEntityRepository,
+    BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
+)
 
 ENTITY_ID = t.TypeVar("ENTITY_ID", bound=t.Hashable)
 ENTITY_TYPE = t.TypeVar("ENTITY_TYPE", bound=Entity[t.Any])
 ENTITY_TABLE = t.TypeVar("ENTITY_TABLE", bound=EntityTable)
+VIEW_TYPE = t.TypeVar("VIEW_TYPE")
+VIEW_TABLE = t.TypeVar("VIEW_TABLE", bound=ViewTable)
 
 
 class BaseSqlAlchemyEntityRepository(
@@ -208,4 +216,60 @@ class BaseSqlAlchemyRepositoryFactory(BaseRepositoryFactory, ABC):
         readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
     ) -> None:
         self._transaction_manager = transaction_manager
+        self._readonly_transaction_manager = readonly_transaction_manager
+
+
+class BaseSqlAlchemyViewRepository(
+    t.Generic[VIEW_TYPE, VIEW_TABLE],
+    BaseViewRepository[VIEW_TYPE, Select[t.Any]],
+    ABC,
+):
+    def __init__(
+        self,
+        table: t.Type[VIEW_TABLE],
+        readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
+    ) -> None:
+        self._table = table
+        self._readonly_transaction_manager = readonly_transaction_manager
+
+    @staticmethod
+    @abstractmethod
+    def to_view(record: VIEW_TABLE) -> VIEW_TYPE:
+        raise NotImplementedError
+
+    async def find_by(self, criteria: Select[t.Any]) -> t.Optional[VIEW_TYPE]:
+        async with self._readonly_transaction_manager.transaction() as trx:
+            result = (await trx.it().execute(criteria)).scalar_one_or_none()
+
+        return self.to_view(result) if result else None
+
+    async def find_all_by(
+        self, criteria: Select[t.Any]
+    ) -> t.Iterable[VIEW_TYPE]:
+        async with self._readonly_transaction_manager.transaction() as trx:
+            result = (await trx.it().execute(criteria)).scalars().all()
+
+        return [self.to_view(record) for record in result]
+
+    async def get_by(self, criteria: Select[t.Any]) -> VIEW_TYPE:
+        async with self._readonly_transaction_manager.transaction() as trx:
+            result = (await trx.it().execute(criteria)).scalar_one()
+
+        return self.to_view(result)
+
+    async def exists_by(self, criteria: Select[t.Any]) -> bool:
+        statement = select(criteria.exists())
+
+        async with self._readonly_transaction_manager.transaction() as trx:
+            return (await trx.it().execute(statement)).scalar() or False
+
+    def select(self) -> Select[t.Any]:
+        return select(self._table)
+
+
+class BaseSqlAlchemyViewRepositoryFactory(BaseViewRepositoryFactory, ABC):
+    def __init__(
+        self,
+        readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
+    ) -> None:
         self._readonly_transaction_manager = readonly_transaction_manager

--- a/pyuow/contrib/sqlalchemy/aio/repository/base.py
+++ b/pyuow/contrib/sqlalchemy/aio/repository/base.py
@@ -221,7 +221,7 @@ class BaseSqlAlchemyRepositoryFactory(BaseRepositoryFactory, ABC):
 
 class BaseSqlAlchemyViewRepository(
     t.Generic[VIEW_TYPE, VIEW_TABLE],
-    BaseViewRepository[VIEW_TYPE, Select[t.Any]],
+    BaseViewRepository[VIEW_TYPE, ColumnElement[bool]],
     ABC,
 ):
     def __init__(
@@ -237,28 +237,36 @@ class BaseSqlAlchemyViewRepository(
     def to_view(record: VIEW_TABLE) -> VIEW_TYPE:
         raise NotImplementedError
 
-    async def find_by(self, criteria: Select[t.Any]) -> t.Optional[VIEW_TYPE]:
+    async def find_by(
+        self, criteria: ColumnElement[bool]
+    ) -> t.Optional[VIEW_TYPE]:
+        statement = self.select().where(criteria)
+
         async with self._readonly_transaction_manager.transaction() as trx:
-            result = (await trx.it().execute(criteria)).scalar_one_or_none()
+            result = (await trx.it().execute(statement)).scalar_one_or_none()
 
         return self.to_view(result) if result else None
 
     async def find_all_by(
-        self, criteria: Select[t.Any]
+        self, criteria: ColumnElement[bool]
     ) -> t.Iterable[VIEW_TYPE]:
+        statement = self.select().where(criteria)
+
         async with self._readonly_transaction_manager.transaction() as trx:
-            result = (await trx.it().execute(criteria)).scalars().all()
+            result = (await trx.it().execute(statement)).scalars().all()
 
         return [self.to_view(record) for record in result]
 
-    async def get_by(self, criteria: Select[t.Any]) -> VIEW_TYPE:
+    async def get_by(self, criteria: ColumnElement[bool]) -> VIEW_TYPE:
+        statement = self.select().where(criteria)
+
         async with self._readonly_transaction_manager.transaction() as trx:
-            result = (await trx.it().execute(criteria)).scalar_one()
+            result = (await trx.it().execute(statement)).scalar_one()
 
         return self.to_view(result)
 
-    async def exists_by(self, criteria: Select[t.Any]) -> bool:
-        statement = select(criteria.exists())
+    async def exists_by(self, criteria: ColumnElement[bool]) -> bool:
+        statement = exists(self._table).where(criteria).select()
 
         async with self._readonly_transaction_manager.transaction() as trx:
             return (await trx.it().execute(statement)).scalar() or False

--- a/pyuow/contrib/sqlalchemy/repository/__init__.py
+++ b/pyuow/contrib/sqlalchemy/repository/__init__.py
@@ -1,9 +1,13 @@
 from .base import (
     BaseSqlAlchemyEntityRepository,
     BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepository,
+    BaseSqlAlchemyViewRepositoryFactory,
 )
 
 __all__ = (
     "BaseSqlAlchemyEntityRepository",
     "BaseSqlAlchemyRepositoryFactory",
+    "BaseSqlAlchemyViewRepository",
+    "BaseSqlAlchemyViewRepositoryFactory",
 )

--- a/pyuow/contrib/sqlalchemy/repository/base.py
+++ b/pyuow/contrib/sqlalchemy/repository/base.py
@@ -25,6 +25,7 @@ from ....contrib.sqlalchemy.tables import (
     AuditedEntityTable,
     EntityTable,
     VersionedEntityTable,
+    ViewTable,
 )
 from ....contrib.sqlalchemy.work.impl import (
     SqlAlchemyReadOnlyTransactionManager,
@@ -36,11 +37,18 @@ from ....entity import (
     SoftDeletableEntity,
     VersionedEntity,
 )
-from ....repository import BaseEntityRepository, BaseRepositoryFactory
+from ....repository import (
+    BaseEntityRepository,
+    BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
+)
 
 ENTITY_ID = t.TypeVar("ENTITY_ID", bound=t.Hashable)
 ENTITY_TYPE = t.TypeVar("ENTITY_TYPE", bound=Entity[t.Any])
 ENTITY_TABLE = t.TypeVar("ENTITY_TABLE", bound=EntityTable)
+VIEW_TYPE = t.TypeVar("VIEW_TYPE")
+VIEW_TABLE = t.TypeVar("VIEW_TABLE", bound=ViewTable)
 
 
 class BaseSqlAlchemyEntityRepository(
@@ -208,4 +216,58 @@ class BaseSqlAlchemyRepositoryFactory(BaseRepositoryFactory, ABC):
         readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
     ) -> None:
         self._transaction_manager = transaction_manager
+        self._readonly_transaction_manager = readonly_transaction_manager
+
+
+class BaseSqlAlchemyViewRepository(
+    t.Generic[VIEW_TYPE, VIEW_TABLE],
+    BaseViewRepository[VIEW_TYPE, Select[t.Any]],
+    ABC,
+):
+    def __init__(
+        self,
+        table: t.Type[VIEW_TABLE],
+        readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
+    ) -> None:
+        self._table = table
+        self._readonly_transaction_manager = readonly_transaction_manager
+
+    @staticmethod
+    @abstractmethod
+    def to_view(record: VIEW_TABLE) -> VIEW_TYPE:
+        raise NotImplementedError
+
+    def find_by(self, criteria: Select[t.Any]) -> t.Optional[VIEW_TYPE]:
+        with self._readonly_transaction_manager.transaction() as trx:
+            result = (trx.it().execute(criteria)).scalar_one_or_none()
+
+        return self.to_view(result) if result else None
+
+    def find_all_by(self, criteria: Select[t.Any]) -> t.Iterable[VIEW_TYPE]:
+        with self._readonly_transaction_manager.transaction() as trx:
+            result = (trx.it().execute(criteria)).scalars().all()
+
+        return [self.to_view(record) for record in result]
+
+    def get_by(self, criteria: Select[t.Any]) -> VIEW_TYPE:
+        with self._readonly_transaction_manager.transaction() as trx:
+            result = (trx.it().execute(criteria)).scalar_one()
+
+        return self.to_view(result)
+
+    def exists_by(self, criteria: Select[t.Any]) -> bool:
+        statement = select(criteria.exists())
+
+        with self._readonly_transaction_manager.transaction() as trx:
+            return (trx.it().execute(statement)).scalar() or False
+
+    def select(self) -> Select[t.Any]:
+        return select(self._table)
+
+
+class BaseSqlAlchemyViewRepositoryFactory(BaseViewRepositoryFactory, ABC):
+    def __init__(
+        self,
+        readonly_transaction_manager: SqlAlchemyReadOnlyTransactionManager,
+    ) -> None:
         self._readonly_transaction_manager = readonly_transaction_manager

--- a/pyuow/contrib/sqlalchemy/repository/base.py
+++ b/pyuow/contrib/sqlalchemy/repository/base.py
@@ -221,7 +221,7 @@ class BaseSqlAlchemyRepositoryFactory(BaseRepositoryFactory, ABC):
 
 class BaseSqlAlchemyViewRepository(
     t.Generic[VIEW_TYPE, VIEW_TABLE],
-    BaseViewRepository[VIEW_TYPE, Select[t.Any]],
+    BaseViewRepository[VIEW_TYPE, ColumnElement[bool]],
     ABC,
 ):
     def __init__(
@@ -237,26 +237,34 @@ class BaseSqlAlchemyViewRepository(
     def to_view(record: VIEW_TABLE) -> VIEW_TYPE:
         raise NotImplementedError
 
-    def find_by(self, criteria: Select[t.Any]) -> t.Optional[VIEW_TYPE]:
+    def find_by(self, criteria: ColumnElement[bool]) -> t.Optional[VIEW_TYPE]:
+        statement = self.select().where(criteria)
+
         with self._readonly_transaction_manager.transaction() as trx:
-            result = (trx.it().execute(criteria)).scalar_one_or_none()
+            result = (trx.it().execute(statement)).scalar_one_or_none()
 
         return self.to_view(result) if result else None
 
-    def find_all_by(self, criteria: Select[t.Any]) -> t.Iterable[VIEW_TYPE]:
+    def find_all_by(
+        self, criteria: ColumnElement[bool]
+    ) -> t.Iterable[VIEW_TYPE]:
+        statement = self.select().where(criteria)
+
         with self._readonly_transaction_manager.transaction() as trx:
-            result = (trx.it().execute(criteria)).scalars().all()
+            result = (trx.it().execute(statement)).scalars().all()
 
         return [self.to_view(record) for record in result]
 
-    def get_by(self, criteria: Select[t.Any]) -> VIEW_TYPE:
+    def get_by(self, criteria: ColumnElement[bool]) -> VIEW_TYPE:
+        statement = self.select().where(criteria)
+
         with self._readonly_transaction_manager.transaction() as trx:
-            result = (trx.it().execute(criteria)).scalar_one()
+            result = (trx.it().execute(statement)).scalar_one()
 
         return self.to_view(result)
 
-    def exists_by(self, criteria: Select[t.Any]) -> bool:
-        statement = select(criteria.exists())
+    def exists_by(self, criteria: ColumnElement[bool]) -> bool:
+        statement = exists(self._table).where(criteria).select()
 
         with self._readonly_transaction_manager.transaction() as trx:
             return (trx.it().execute(statement)).scalar() or False

--- a/pyuow/contrib/sqlalchemy/tables/__init__.py
+++ b/pyuow/contrib/sqlalchemy/tables/__init__.py
@@ -4,6 +4,7 @@ from .base import (
     EntityTable,
     SoftDeletableEntityTable,
     VersionedEntityTable,
+    ViewTable,
 )
 
 __all__ = (
@@ -12,4 +13,5 @@ __all__ = (
     "EntityTable",
     "SoftDeletableEntityTable",
     "VersionedEntityTable",
+    "ViewTable",
 )

--- a/pyuow/contrib/sqlalchemy/tables/base.py
+++ b/pyuow/contrib/sqlalchemy/tables/base.py
@@ -52,3 +52,7 @@ class SoftDeletableEntityTable(EntityTable):
 class VersionedEntityTable(EntityTable):
     __abstract__ = True
     version: Mapped[int] = mapped_column(Integer(), nullable=False)
+
+
+class ViewTable(BaseTable):
+    __abstract__ = True

--- a/pyuow/repository/__init__.py
+++ b/pyuow/repository/__init__.py
@@ -2,6 +2,8 @@ from .base import (
     BaseEntityRepository,
     BaseReadOnlyEntityRepository,
     BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
     BaseWriteOnlyEntityRepository,
 )
 from .domain import DomainRepository
@@ -10,6 +12,8 @@ __all__ = (
     "BaseEntityRepository",
     "BaseReadOnlyEntityRepository",
     "BaseRepositoryFactory",
+    "BaseViewRepository",
+    "BaseViewRepositoryFactory",
     "BaseWriteOnlyEntityRepository",
     "DomainRepository",
 )

--- a/pyuow/repository/aio/__init__.py
+++ b/pyuow/repository/aio/__init__.py
@@ -2,6 +2,8 @@ from .base import (
     BaseEntityRepository,
     BaseReadOnlyEntityRepository,
     BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
     BaseWriteOnlyEntityRepository,
 )
 from .domain import DomainRepository
@@ -10,6 +12,8 @@ __all__ = (
     "BaseEntityRepository",
     "BaseReadOnlyEntityRepository",
     "BaseRepositoryFactory",
+    "BaseViewRepository",
+    "BaseViewRepositoryFactory",
     "BaseWriteOnlyEntityRepository",
     "DomainRepository",
 )

--- a/pyuow/repository/aio/base.py
+++ b/pyuow/repository/aio/base.py
@@ -6,6 +6,8 @@ from ...entity import Entity
 
 ENTITY_ID = t.TypeVar("ENTITY_ID", bound=t.Hashable)
 ENTITY_TYPE = t.TypeVar("ENTITY_TYPE", bound=Entity[t.Any])
+VIEW_TYPE = t.TypeVar("VIEW_TYPE")
+CRITERIA = t.TypeVar("CRITERIA")
 
 
 class BaseReadOnlyEntityRepository(t.Generic[ENTITY_ID, ENTITY_TYPE], ABC):
@@ -66,6 +68,24 @@ class BaseEntityRepository(
     pass
 
 
+class BaseViewRepository(t.Generic[VIEW_TYPE, CRITERIA], ABC):
+    @abc.abstractmethod
+    async def find_by(self, criteria: CRITERIA) -> t.Optional[VIEW_TYPE]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def find_all_by(self, criteria: CRITERIA) -> t.Iterable[VIEW_TYPE]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def get_by(self, criteria: CRITERIA) -> VIEW_TYPE:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def exists_by(self, criteria: CRITERIA) -> bool:
+        raise NotImplementedError
+
+
 class BaseRepositoryFactory(ABC):
     @property
     @abc.abstractmethod
@@ -85,4 +105,26 @@ class BaseRepositoryFactory(ABC):
         except KeyError as e:
             raise KeyError(
                 f"Repository for {entity_type.__name__} is not registered"
+            ) from e
+
+
+class BaseViewRepositoryFactory(ABC):
+    @property
+    @abc.abstractmethod
+    def views(
+        self,
+    ) -> t.Mapping[
+        t.Type[t.Any],
+        BaseViewRepository[t.Any, t.Any],
+    ]:
+        raise NotImplementedError
+
+    def view_for(
+        self, view_type: t.Type[VIEW_TYPE]
+    ) -> BaseViewRepository[VIEW_TYPE, t.Any]:
+        try:
+            return self.views[view_type]
+        except KeyError as e:
+            raise KeyError(
+                f"View repository for {view_type.__name__} is not registered"
             ) from e

--- a/pyuow/repository/aio/base.py
+++ b/pyuow/repository/aio/base.py
@@ -77,14 +77,6 @@ class BaseViewRepository(t.Generic[VIEW_TYPE, CRITERIA], ABC):
     async def find_all_by(self, criteria: CRITERIA) -> t.Iterable[VIEW_TYPE]:
         raise NotImplementedError
 
-    @abc.abstractmethod
-    async def get_by(self, criteria: CRITERIA) -> VIEW_TYPE:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    async def exists_by(self, criteria: CRITERIA) -> bool:
-        raise NotImplementedError
-
 
 class BaseRepositoryFactory(ABC):
     @property

--- a/pyuow/repository/base.py
+++ b/pyuow/repository/base.py
@@ -77,14 +77,6 @@ class BaseViewRepository(t.Generic[VIEW_TYPE, CRITERIA], ABC):
     def find_all_by(self, criteria: CRITERIA) -> t.Iterable[VIEW_TYPE]:
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def get_by(self, criteria: CRITERIA) -> VIEW_TYPE:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def exists_by(self, criteria: CRITERIA) -> bool:
-        raise NotImplementedError
-
 
 class BaseRepositoryFactory(ABC):
     @property

--- a/pyuow/repository/base.py
+++ b/pyuow/repository/base.py
@@ -6,6 +6,8 @@ from ..entity import Entity
 
 ENTITY_ID = t.TypeVar("ENTITY_ID", bound=t.Hashable)
 ENTITY_TYPE = t.TypeVar("ENTITY_TYPE", bound=Entity[t.Any])
+VIEW_TYPE = t.TypeVar("VIEW_TYPE")
+CRITERIA = t.TypeVar("CRITERIA")
 
 
 class BaseReadOnlyEntityRepository(t.Generic[ENTITY_ID, ENTITY_TYPE], ABC):
@@ -66,6 +68,24 @@ class BaseEntityRepository(
     pass
 
 
+class BaseViewRepository(t.Generic[VIEW_TYPE, CRITERIA], ABC):
+    @abc.abstractmethod
+    def find_by(self, criteria: CRITERIA) -> t.Optional[VIEW_TYPE]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def find_all_by(self, criteria: CRITERIA) -> t.Iterable[VIEW_TYPE]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_by(self, criteria: CRITERIA) -> VIEW_TYPE:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def exists_by(self, criteria: CRITERIA) -> bool:
+        raise NotImplementedError
+
+
 class BaseRepositoryFactory(ABC):
     @property
     @abc.abstractmethod
@@ -85,4 +105,26 @@ class BaseRepositoryFactory(ABC):
         except KeyError as e:
             raise KeyError(
                 f"Repository for {entity_type.__name__} is not registered"
+            ) from e
+
+
+class BaseViewRepositoryFactory(ABC):
+    @property
+    @abc.abstractmethod
+    def views(
+        self,
+    ) -> t.Mapping[
+        t.Type[t.Any],
+        BaseViewRepository[t.Any, t.Any],
+    ]:
+        raise NotImplementedError
+
+    def view_for(
+        self, view_type: t.Type[VIEW_TYPE]
+    ) -> BaseViewRepository[VIEW_TYPE, t.Any]:
+        try:
+            return self.views[view_type]
+        except KeyError as e:
+            raise KeyError(
+                f"View repository for {view_type.__name__} is not registered"
             ) from e

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -222,7 +222,9 @@ The integration lives under `pyuow.contrib.sqlalchemy` (sync) and `pyuow.contrib
 - `SqlAlchemyTransactionManager` / `SqlAlchemyReadOnlyTransactionManager` — for `TransactionalWorkManager`.
 - `BaseSqlAlchemyEntityRepository` — implements `BaseEntityRepository` against `EntityTable` mixins.
 - `BaseSqlAlchemyRepositoryFactory` — wires repositories for `DomainTransactionalWorkManager`.
+- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query with `select()` + `find_by` / `find_all_by` / `get_by` / `exists_by`.
 - `EntityTable` / `AuditedEntityTable` / `SoftDeletableEntityTable` / `VersionedEntityTable` — `DeclarativeBase` mixins.
+- `ViewTable` — `DeclarativeBase` mixin for a mapped database view; pair it with a plain frozen dataclass read model.
 
 Install with `pip install "pyuow[sqlalchemy]"`.
 

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.10.0 -->
+<!-- Generated for pyuow 0.11.0 -->
 
 ## When to use PyUoW
 

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -222,7 +222,7 @@ The integration lives under `pyuow.contrib.sqlalchemy` (sync) and `pyuow.contrib
 - `SqlAlchemyTransactionManager` / `SqlAlchemyReadOnlyTransactionManager` — for `TransactionalWorkManager`.
 - `BaseSqlAlchemyEntityRepository` — implements `BaseEntityRepository` against `EntityTable` mixins.
 - `BaseSqlAlchemyRepositoryFactory` — wires repositories for `DomainTransactionalWorkManager`.
-- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query with `select()` + `find_by` / `find_all_by` / `get_by` / `exists_by`.
+- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query by whereclause with `find_by` / `find_all_by` / `get_by` / `exists_by`; `select()` is the escape hatch for ordering, limits, or joins.
 - `EntityTable` / `AuditedEntityTable` / `SoftDeletableEntityTable` / `VersionedEntityTable` — `DeclarativeBase` mixins.
 - `ViewTable` — `DeclarativeBase` mixin for a mapped database view; pair it with a plain frozen dataclass read model.
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -222,7 +222,9 @@ The integration lives under `pyuow.contrib.sqlalchemy` (sync) and `pyuow.contrib
 - `SqlAlchemyTransactionManager` / `SqlAlchemyReadOnlyTransactionManager` — for `TransactionalWorkManager`.
 - `BaseSqlAlchemyEntityRepository` — implements `BaseEntityRepository` against `EntityTable` mixins.
 - `BaseSqlAlchemyRepositoryFactory` — wires repositories for `DomainTransactionalWorkManager`.
+- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query with `select()` + `find_by` / `find_all_by` / `get_by` / `exists_by`.
 - `EntityTable` / `AuditedEntityTable` / `SoftDeletableEntityTable` / `VersionedEntityTable` — `DeclarativeBase` mixins.
+- `ViewTable` — `DeclarativeBase` mixin for a mapped database view; pair it with a plain frozen dataclass read model.
 
 Install with `pip install "pyuow[sqlalchemy]"`.
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.10.0 -->
+<!-- Generated for pyuow 0.11.0 -->
 
 ## When to use PyUoW
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -222,7 +222,7 @@ The integration lives under `pyuow.contrib.sqlalchemy` (sync) and `pyuow.contrib
 - `SqlAlchemyTransactionManager` / `SqlAlchemyReadOnlyTransactionManager` — for `TransactionalWorkManager`.
 - `BaseSqlAlchemyEntityRepository` — implements `BaseEntityRepository` against `EntityTable` mixins.
 - `BaseSqlAlchemyRepositoryFactory` — wires repositories for `DomainTransactionalWorkManager`.
-- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query with `select()` + `find_by` / `find_all_by` / `get_by` / `exists_by`.
+- `BaseSqlAlchemyViewRepository` / `BaseSqlAlchemyViewRepositoryFactory` — read-only repositories over database views: implement `to_view`, then query by whereclause with `find_by` / `find_all_by` / `get_by` / `exists_by`; `select()` is the escape hatch for ordering, limits, or joins.
 - `EntityTable` / `AuditedEntityTable` / `SoftDeletableEntityTable` / `VersionedEntityTable` — `DeclarativeBase` mixins.
 - `ViewTable` — `DeclarativeBase` mixin for a mapped database view; pair it with a plain frozen dataclass read model.
 

--- a/tests/contrib/sqlalchemy/aio/persistence/test_base.py
+++ b/tests/contrib/sqlalchemy/aio/persistence/test_base.py
@@ -12,23 +12,27 @@ from pyuow.clock import offset_naive_utcnow
 from pyuow.contrib.sqlalchemy.aio.repository import (
     BaseSqlAlchemyEntityRepository,
     BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepository,
+    BaseSqlAlchemyViewRepositoryFactory,
 )
 from pyuow.contrib.sqlalchemy.aio.work import (
     SqlAlchemyReadOnlyTransactionManager,
     SqlAlchemyTransactionManager,
 )
 from pyuow.entity import Entity, Version
-from pyuow.repository.aio import BaseEntityRepository
+from pyuow.repository.aio import BaseEntityRepository, BaseViewRepository
 from tests.fake_entities import (
     FakeAuditedEntity,
     FakeEntity,
     FakeEntityId,
     FakeVersionedEntity,
 )
+from tests.fake_views import FakeEntityView
 
 from ...fake_tables import (
     FakeAuditedEntityTable,
     FakeEntityTable,
+    FakeEntityViewTable,
     FakeVersionedEntityTable,
 )
 
@@ -99,7 +103,43 @@ class FakeVersionedEntityRepository(
         )
 
 
-class FakeRepositoryFactory(BaseSqlAlchemyRepositoryFactory):
+class FakeEntityViewRepository(
+    BaseSqlAlchemyViewRepository[FakeEntityView, FakeEntityViewTable]
+):
+    @staticmethod
+    def to_view(record: FakeEntityViewTable) -> FakeEntityView:
+        return FakeEntityView(
+            id=FakeEntityId(record.id),
+            field=record.field,
+            upper_field=record.upper_field,
+        )
+
+    async def find_by_field(self, field: str) -> t.Optional[FakeEntityView]:
+        return await self.find_by(
+            self.select().where(self._table.field == field)
+        )
+
+    async def find_all_by_field(
+        self, field: str
+    ) -> t.Iterable[FakeEntityView]:
+        return await self.find_all_by(
+            self.select().where(self._table.field == field)
+        )
+
+    async def get_by_field(self, field: str) -> FakeEntityView:
+        return await self.get_by(
+            self.select().where(self._table.field == field)
+        )
+
+    async def exists_by_field(self, field: str) -> bool:
+        return await self.exists_by(
+            self.select().where(self._table.field == field)
+        )
+
+
+class FakeRepositoryFactory(
+    BaseSqlAlchemyRepositoryFactory, BaseSqlAlchemyViewRepositoryFactory
+):
     @property
     def repositories(
         self,
@@ -121,6 +161,20 @@ class FakeRepositoryFactory(BaseSqlAlchemyRepositoryFactory):
             FakeEntity: FakeEntityRepository(
                 FakeEntityTable,
                 self._transaction_manager,
+                self._readonly_transaction_manager,
+            ),
+        }
+
+    @property
+    def views(
+        self,
+    ) -> t.Mapping[
+        t.Type[t.Any],
+        BaseViewRepository[t.Any, t.Any],
+    ]:
+        return {
+            FakeEntityView: FakeEntityViewRepository(
+                FakeEntityViewTable,
                 self._readonly_transaction_manager,
             ),
         }
@@ -395,3 +449,107 @@ class TestSqlAlchemyEntityRepository:
         result = await audited_entity_repository.delete_all([entity1, entity2])
         # then
         assert result is True
+
+
+@pytest.mark.skip_on_ci
+class TestSqlAlchemyViewRepository:
+    @pytest.fixture
+    def entity_repository(
+        self, repository_factory: FakeRepositoryFactory
+    ) -> BaseEntityRepository[FakeEntityId, FakeEntity]:
+        return repository_factory.repo_for(FakeEntity)
+
+    @pytest.fixture
+    def entity_view_repository(
+        self, repository_factory: FakeRepositoryFactory
+    ) -> BaseViewRepository[FakeEntityView, t.Any]:
+        return repository_factory.view_for(FakeEntityView)
+
+    async def test_async_find_by_should_find_view(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        await entity_repository.add(entity)
+        # when
+        result = await entity_view_repository.find_by_field(entity.field)
+        # then
+        assert result == FakeEntityView(
+            id=entity.id,
+            field=entity.field,
+            upper_field=entity.field.upper(),
+        )
+
+    async def test_async_find_by_should_return_none_when_no_view_matches(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = await entity_view_repository.find_by_field(str(uuid4()))
+        # then
+        assert result is None
+
+    async def test_async_find_all_by_should_find_all_views(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        field = str(uuid4())
+        entity1 = FakeEntity(id=FakeEntityId(uuid4()), field=field)
+        entity2 = FakeEntity(id=FakeEntityId(uuid4()), field=field)
+        await entity_repository.add_all([entity1, entity2])
+        # when
+        result = await entity_view_repository.find_all_by_field(field)
+        # then
+        assert {view.id for view in result} == {entity1.id, entity2.id}
+
+    async def test_find_all_by_should_return_empty_sequence_when_no_view_matches(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = await entity_view_repository.find_all_by_field(str(uuid4()))
+        # then
+        assert result == []
+
+    async def test_async_get_by_should_get_existing_view(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        await entity_repository.add(entity)
+        # when
+        result = await entity_view_repository.get_by_field(entity.field)
+        # then
+        assert result.upper_field == entity.field.upper()
+
+    async def test_async_get_by_should_raise_if_no_view_exists(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when / then
+        with pytest.raises(NoResultFound):
+            await entity_view_repository.get_by_field(str(uuid4()))
+
+    async def test_async_exists_by_should_return_true_if_view_exists(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        await entity_repository.add(entity)
+        # when
+        result = await entity_view_repository.exists_by_field(entity.field)
+        # then
+        assert result is True
+
+    async def test_async_exists_by_should_return_false_if_no_view_found(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = await entity_view_repository.exists_by_field(str(uuid4()))
+        # then
+        assert result is False

--- a/tests/contrib/sqlalchemy/aio/persistence/test_base.py
+++ b/tests/contrib/sqlalchemy/aio/persistence/test_base.py
@@ -115,26 +115,18 @@ class FakeEntityViewRepository(
         )
 
     async def find_by_field(self, field: str) -> t.Optional[FakeEntityView]:
-        return await self.find_by(
-            self.select().where(self._table.field == field)
-        )
+        return await self.find_by(self._table.field == field)
 
     async def find_all_by_field(
         self, field: str
     ) -> t.Iterable[FakeEntityView]:
-        return await self.find_all_by(
-            self.select().where(self._table.field == field)
-        )
+        return await self.find_all_by(self._table.field == field)
 
     async def get_by_field(self, field: str) -> FakeEntityView:
-        return await self.get_by(
-            self.select().where(self._table.field == field)
-        )
+        return await self.get_by(self._table.field == field)
 
     async def exists_by_field(self, field: str) -> bool:
-        return await self.exists_by(
-            self.select().where(self._table.field == field)
-        )
+        return await self.exists_by(self._table.field == field)
 
 
 class FakeRepositoryFactory(

--- a/tests/contrib/sqlalchemy/fake_tables.py
+++ b/tests/contrib/sqlalchemy/fake_tables.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from sqlalchemy.orm import Mapped
+from uuid import UUID
+
+from sqlalchemy.orm import Mapped, mapped_column
 
 from pyuow.contrib.sqlalchemy.tables import (
     AuditedEntityTable,
     EntityTable,
     SoftDeletableEntityTable,
     VersionedEntityTable,
+    ViewTable,
 )
 
 
@@ -26,3 +29,11 @@ class FakeVersionedEntityTable(VersionedEntityTable):
     __tablename__ = "fake_versioned_entities"
 
     field: Mapped[str]
+
+
+class FakeEntityViewTable(ViewTable):
+    __tablename__ = "fake_entities_view"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    field: Mapped[str]
+    upper_field: Mapped[str]

--- a/tests/contrib/sqlalchemy/persistence/test_base.py
+++ b/tests/contrib/sqlalchemy/persistence/test_base.py
@@ -115,18 +115,16 @@ class FakeEntityViewRepository(
         )
 
     def find_by_field(self, field: str) -> t.Optional[FakeEntityView]:
-        return self.find_by(self.select().where(self._table.field == field))
+        return self.find_by(self._table.field == field)
 
     def find_all_by_field(self, field: str) -> t.Iterable[FakeEntityView]:
-        return self.find_all_by(
-            self.select().where(self._table.field == field)
-        )
+        return self.find_all_by(self._table.field == field)
 
     def get_by_field(self, field: str) -> FakeEntityView:
-        return self.get_by(self.select().where(self._table.field == field))
+        return self.get_by(self._table.field == field)
 
     def exists_by_field(self, field: str) -> bool:
-        return self.exists_by(self.select().where(self._table.field == field))
+        return self.exists_by(self._table.field == field)
 
 
 class FakeRepositoryFactory(

--- a/tests/contrib/sqlalchemy/persistence/test_base.py
+++ b/tests/contrib/sqlalchemy/persistence/test_base.py
@@ -12,23 +12,27 @@ from pyuow.clock import offset_naive_utcnow
 from pyuow.contrib.sqlalchemy.repository import (
     BaseSqlAlchemyEntityRepository,
     BaseSqlAlchemyRepositoryFactory,
+    BaseSqlAlchemyViewRepository,
+    BaseSqlAlchemyViewRepositoryFactory,
 )
 from pyuow.contrib.sqlalchemy.work import (
     SqlAlchemyReadOnlyTransactionManager,
     SqlAlchemyTransactionManager,
 )
 from pyuow.entity import Entity, Version
-from pyuow.repository import BaseEntityRepository
+from pyuow.repository import BaseEntityRepository, BaseViewRepository
 from tests.fake_entities import (
     FakeAuditedEntity,
     FakeEntity,
     FakeEntityId,
     FakeVersionedEntity,
 )
+from tests.fake_views import FakeEntityView
 
 from ..fake_tables import (
     FakeAuditedEntityTable,
     FakeEntityTable,
+    FakeEntityViewTable,
     FakeVersionedEntityTable,
 )
 
@@ -99,7 +103,35 @@ class FakeVersionedEntityRepository(
         )
 
 
-class FakeRepositoryFactory(BaseSqlAlchemyRepositoryFactory):
+class FakeEntityViewRepository(
+    BaseSqlAlchemyViewRepository[FakeEntityView, FakeEntityViewTable]
+):
+    @staticmethod
+    def to_view(record: FakeEntityViewTable) -> FakeEntityView:
+        return FakeEntityView(
+            id=FakeEntityId(record.id),
+            field=record.field,
+            upper_field=record.upper_field,
+        )
+
+    def find_by_field(self, field: str) -> t.Optional[FakeEntityView]:
+        return self.find_by(self.select().where(self._table.field == field))
+
+    def find_all_by_field(self, field: str) -> t.Iterable[FakeEntityView]:
+        return self.find_all_by(
+            self.select().where(self._table.field == field)
+        )
+
+    def get_by_field(self, field: str) -> FakeEntityView:
+        return self.get_by(self.select().where(self._table.field == field))
+
+    def exists_by_field(self, field: str) -> bool:
+        return self.exists_by(self.select().where(self._table.field == field))
+
+
+class FakeRepositoryFactory(
+    BaseSqlAlchemyRepositoryFactory, BaseSqlAlchemyViewRepositoryFactory
+):
     @property
     def repositories(
         self,
@@ -121,6 +153,20 @@ class FakeRepositoryFactory(BaseSqlAlchemyRepositoryFactory):
             FakeEntity: FakeEntityRepository(
                 FakeEntityTable,
                 self._transaction_manager,
+                self._readonly_transaction_manager,
+            ),
+        }
+
+    @property
+    def views(
+        self,
+    ) -> t.Mapping[
+        t.Type[t.Any],
+        BaseViewRepository[t.Any, t.Any],
+    ]:
+        return {
+            FakeEntityView: FakeEntityViewRepository(
+                FakeEntityViewTable,
                 self._readonly_transaction_manager,
             ),
         }
@@ -389,3 +435,107 @@ class TestSqlAlchemyEntityRepository:
         result = audited_entity_repository.delete_all([entity1, entity2])
         # then
         assert result is True
+
+
+@pytest.mark.skip_on_ci
+class TestSqlAlchemyViewRepository:
+    @pytest.fixture
+    def entity_repository(
+        self, repository_factory: FakeRepositoryFactory
+    ) -> BaseEntityRepository[FakeEntityId, FakeEntity]:
+        return repository_factory.repo_for(FakeEntity)
+
+    @pytest.fixture
+    def entity_view_repository(
+        self, repository_factory: FakeRepositoryFactory
+    ) -> BaseViewRepository[FakeEntityView, t.Any]:
+        return repository_factory.view_for(FakeEntityView)
+
+    def test_find_by_should_find_view(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        entity_repository.add(entity)
+        # when
+        result = entity_view_repository.find_by_field(entity.field)
+        # then
+        assert result == FakeEntityView(
+            id=entity.id,
+            field=entity.field,
+            upper_field=entity.field.upper(),
+        )
+
+    def test_find_by_should_return_none_when_no_view_matches(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = entity_view_repository.find_by_field(str(uuid4()))
+        # then
+        assert result is None
+
+    def test_find_all_by_should_find_all_views(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        field = str(uuid4())
+        entity1 = FakeEntity(id=FakeEntityId(uuid4()), field=field)
+        entity2 = FakeEntity(id=FakeEntityId(uuid4()), field=field)
+        entity_repository.add_all([entity1, entity2])
+        # when
+        result = entity_view_repository.find_all_by_field(field)
+        # then
+        assert {view.id for view in result} == {entity1.id, entity2.id}
+
+    def test_find_all_by_should_return_empty_sequence_when_no_view_matches(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = entity_view_repository.find_all_by_field(str(uuid4()))
+        # then
+        assert result == []
+
+    def test_get_by_should_get_existing_view(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        entity_repository.add(entity)
+        # when
+        result = entity_view_repository.get_by_field(entity.field)
+        # then
+        assert result.upper_field == entity.field.upper()
+
+    def test_get_by_should_raise_if_no_view_exists(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when / then
+        with pytest.raises(NoResultFound):
+            entity_view_repository.get_by_field(str(uuid4()))
+
+    def test_exists_by_should_return_true_if_view_exists(
+        self,
+        entity_repository: FakeEntityRepository,
+        entity_view_repository: FakeEntityViewRepository,
+    ) -> None:
+        # given
+        entity = FakeEntity(id=FakeEntityId(uuid4()), field=str(uuid4()))
+        entity_repository.add(entity)
+        # when
+        result = entity_view_repository.exists_by_field(entity.field)
+        # then
+        assert result is True
+
+    def test_exists_by_should_return_false_if_no_view_found(
+        self, entity_view_repository: FakeEntityViewRepository
+    ) -> None:
+        # when
+        result = entity_view_repository.exists_by_field(str(uuid4()))
+        # then
+        assert result is False

--- a/tests/contrib/sqlalchemy/test_db_schema.sql
+++ b/tests/contrib/sqlalchemy/test_db_schema.sql
@@ -18,4 +18,10 @@ CREATE TABLE IF NOT EXISTS fake_entities
 (
     id           uuid NOT NULL PRIMARY KEY,
     field        varchar(255) NOT NULL
-)
+);
+
+CREATE OR REPLACE VIEW fake_entities_view AS
+SELECT id,
+       field,
+       upper(field) AS upper_field
+FROM fake_entities

--- a/tests/fake_views.py
+++ b/tests/fake_views.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tests.fake_entities import FakeEntityId
+
+
+@dataclass(frozen=True)
+class FakeView:
+    field: str = "test"
+
+
+@dataclass(frozen=True)
+class FakeEntityView:
+    id: FakeEntityId
+    field: str
+    upper_field: str

--- a/tests/repository/aio/test_base.py
+++ b/tests/repository/aio/test_base.py
@@ -4,8 +4,14 @@ from unittest.mock import Mock
 import pytest
 
 from pyuow.entity import Entity
-from pyuow.repository.aio import BaseEntityRepository, BaseRepositoryFactory
+from pyuow.repository.aio import (
+    BaseEntityRepository,
+    BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
+)
 from tests.fake_entities import FakeEntity, FakeEntityId
+from tests.fake_views import FakeView
 
 
 class FakeBaseEntityRepository(BaseEntityRepository[FakeEntityId, FakeEntity]):
@@ -73,3 +79,44 @@ class TestRepositoryFactory:
         # when
         with pytest.raises(KeyError):
             factory.repo_for(Mock)
+
+
+class FakeBaseViewRepository(BaseViewRepository[FakeView, str]):
+    async def find_by(self, criteria: str) -> t.Optional[FakeView]:
+        return None
+
+    async def find_all_by(self, criteria: str) -> t.Iterable[FakeView]:
+        return []
+
+    async def get_by(self, criteria: str) -> FakeView:
+        return FakeView(field=criteria)
+
+    async def exists_by(self, criteria: str) -> bool:
+        return True
+
+
+class FakeViewRepositoryFactory(BaseViewRepositoryFactory):
+    @property
+    def views(
+        self,
+    ) -> t.Mapping[t.Type[t.Any], BaseViewRepository[t.Any, t.Any]]:
+        return {FakeView: FakeBaseViewRepository()}
+
+
+class TestViewRepositoryFactory:
+    def test_async_view_for_should_return_proper_repository_for_view_type(
+        self,
+    ) -> None:
+        # given
+        factory = FakeViewRepositoryFactory()
+        # then
+        assert isinstance(factory.view_for(FakeView), FakeBaseViewRepository)
+
+    def test_async_view_for_should_raise_if_no_repository_for_view_type(
+        self,
+    ) -> None:
+        # given
+        factory = FakeViewRepositoryFactory()
+        # when
+        with pytest.raises(KeyError):
+            factory.view_for(Mock)

--- a/tests/repository/aio/test_base.py
+++ b/tests/repository/aio/test_base.py
@@ -88,12 +88,6 @@ class FakeBaseViewRepository(BaseViewRepository[FakeView, str]):
     async def find_all_by(self, criteria: str) -> t.Iterable[FakeView]:
         return []
 
-    async def get_by(self, criteria: str) -> FakeView:
-        return FakeView(field=criteria)
-
-    async def exists_by(self, criteria: str) -> bool:
-        return True
-
 
 class FakeViewRepositoryFactory(BaseViewRepositoryFactory):
     @property

--- a/tests/repository/test_base.py
+++ b/tests/repository/test_base.py
@@ -88,12 +88,6 @@ class FakeBaseViewRepository(BaseViewRepository[FakeView, str]):
     def find_all_by(self, criteria: str) -> t.Iterable[FakeView]:
         return []
 
-    def get_by(self, criteria: str) -> FakeView:
-        return FakeView(field=criteria)
-
-    def exists_by(self, criteria: str) -> bool:
-        return True
-
 
 class FakeViewRepositoryFactory(BaseViewRepositoryFactory):
     @property

--- a/tests/repository/test_base.py
+++ b/tests/repository/test_base.py
@@ -4,8 +4,14 @@ from unittest.mock import Mock
 import pytest
 
 from pyuow.entity import Entity
-from pyuow.repository import BaseEntityRepository, BaseRepositoryFactory
+from pyuow.repository import (
+    BaseEntityRepository,
+    BaseRepositoryFactory,
+    BaseViewRepository,
+    BaseViewRepositoryFactory,
+)
 from tests.fake_entities import FakeEntity, FakeEntityId
+from tests.fake_views import FakeView
 
 
 class FakeBaseEntityRepository(BaseEntityRepository[FakeEntityId, FakeEntity]):
@@ -73,3 +79,44 @@ class TestRepositoryFactory:
         # when / then
         with pytest.raises(KeyError):
             factory.repo_for(Mock)
+
+
+class FakeBaseViewRepository(BaseViewRepository[FakeView, str]):
+    def find_by(self, criteria: str) -> t.Optional[FakeView]:
+        return None
+
+    def find_all_by(self, criteria: str) -> t.Iterable[FakeView]:
+        return []
+
+    def get_by(self, criteria: str) -> FakeView:
+        return FakeView(field=criteria)
+
+    def exists_by(self, criteria: str) -> bool:
+        return True
+
+
+class FakeViewRepositoryFactory(BaseViewRepositoryFactory):
+    @property
+    def views(
+        self,
+    ) -> t.Mapping[t.Type[t.Any], BaseViewRepository[t.Any, t.Any]]:
+        return {FakeView: FakeBaseViewRepository()}
+
+
+class TestViewRepositoryFactory:
+    def test_view_for_should_return_proper_repository_for_view_type(
+        self,
+    ) -> None:
+        # given
+        factory = FakeViewRepositoryFactory()
+        # then
+        assert isinstance(factory.view_for(FakeView), FakeBaseViewRepository)
+
+    def test_view_for_should_raise_if_no_repository_for_view_type(
+        self,
+    ) -> None:
+        # given
+        factory = FakeViewRepositoryFactory()
+        # when / then
+        with pytest.raises(KeyError):
+            factory.view_for(Mock)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,7 +546,7 @@ class TestMain:
         assert main(["--version"]) == 0
         captured = capsys.readouterr()
         # then
-        assert captured.out == "pyuow 0.10.0\n"
+        assert captured.out == "pyuow 0.11.0\n"
         assert captured.err == ""
 
     # given


### PR DESCRIPTION
Add a read-only repository tier alongside the entity repositories, for projecting database views into read models.

Core (sync + aio):
- BaseViewRepository[VIEW_TYPE, CRITERIA] - find_by / find_all_by / get_by / exists_by. Criteria-driven rather than id-keyed, since a view is rarely addressed by an id known upfront.
- BaseViewRepositoryFactory - a views mapping plus a generically typed view_for(), mirroring BaseRepositoryFactory.

SQLAlchemy contrib (sync + aio):
- ViewTable declarative mixin for mapping a database view.
- BaseSqlAlchemyViewRepository - binds CRITERIA to Select, exposes select() to build statements, and requires only to_view().
- BaseSqlAlchemyViewRepositoryFactory - takes the read-only transaction manager only, and composes with BaseSqlAlchemyRepositoryFactory.

Read models stay plain frozen dataclasses; no base class is imposed.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes - it will be used in the changelog
* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI
* [ ] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**
