### PR TITLE
feat(sqlalchemy): mark ViewTable with is_view table info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyuow"
-version = "0.11.0"
+version = "0.11.1"
 description = "Python custom implementation of unit of work pattern"
 readme = "README.md"
 license = "MIT"

--- a/pyuow/contrib/sqlalchemy/tables/base.py
+++ b/pyuow/contrib/sqlalchemy/tables/base.py
@@ -56,3 +56,4 @@ class VersionedEntityTable(EntityTable):
 
 class ViewTable(BaseTable):
     __abstract__ = True
+    __table_args__ = {"info": {"is_view": True}}

--- a/pyuow_cli/assets/skills/claude.md
+++ b/pyuow_cli/assets/skills/claude.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.11.0 -->
+<!-- Generated for pyuow 0.11.1 -->
 
 ## When to use PyUoW
 

--- a/pyuow_cli/assets/skills/opencode.md
+++ b/pyuow_cli/assets/skills/opencode.md
@@ -3,7 +3,7 @@ name: pyuow
 description: Use this skill whenever working with the PyUoW library (Unit of Work pattern for Python) — composable units, flows, Result, transactional work managers, and the SQLAlchemy adapter.
 ---
 
-<!-- Generated for pyuow 0.11.0 -->
+<!-- Generated for pyuow 0.11.1 -->
 
 ## When to use PyUoW
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,7 +546,7 @@ class TestMain:
         assert main(["--version"]) == 0
         captured = capsys.readouterr()
         # then
-        assert captured.out == "pyuow 0.11.0\n"
+        assert captured.out == "pyuow 0.11.1\n"
         assert captured.err == ""
 
     # given


### PR DESCRIPTION
`ViewTable` now carries `__table_args__ = {"info": {"is_view": True}}`, so every mapped view subclass ends up with `Table.info["is_view"] is True`.

That gives a cheap, dialect-agnostic way to tell views apart from real tables when walking `MetaData` - most importantly for schema tooling (Alembic autogenerate, `create_all`/`drop_all` helpers), which otherwise treats a mapped view as a table it should create or drop.

Entity tables are untouched (`info` stays `{}`), and no runtime behaviour of the repositories changes.

Patch bump to 0.11.1 - version stamp updated in both CLI skill assets and the `--version` assertion in `tests/test_cli.py`, matching the 0.11.0 bump.

Verified: `ruff check` / `ruff format --check` / `mypy .` clean, 237 tests pass at 99.88% coverage, and the marker was confirmed on a concrete view table with entity tables unaffected.